### PR TITLE
Client interface defualt language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ local.properties
 # composer / packagist
 composer.lock
 vendor/
+
+# IntelliJ based IDEs
+.idea/

--- a/src/AbstractClient.php
+++ b/src/AbstractClient.php
@@ -101,9 +101,9 @@ abstract class AbstractClient implements ClientInterface
     }
     
     /**
-     * Sets the default language
+     * (non-PHPdoc)
      *
-     * @param string $language
+     * @see \Aiphilos\Api\ClientInterface::setDefaultLanguage()
      *
      * @throws \UnexpectedValueException
      */
@@ -116,7 +116,9 @@ abstract class AbstractClient implements ClientInterface
     }
     
     /**
-     * @return string
+     * (non-PHPdoc)
+     *
+     * @see \Aiphilos\Api\ClientInterface::getDefaultLanguage()
      */
     public function getDefaultLanguage()
     {

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -23,4 +23,16 @@ interface ClientInterface
      * @return String[]
      */
     public function getLanguages();
+
+    /**
+     * Sets the default language
+     *
+     * @param string $language
+     */
+    public function setDefaultLanguage($language);
+
+    /**
+     * @return string
+     */
+    public function getDefaultLanguage();
 }


### PR DESCRIPTION
Added the methods 'setDefaultLanguage' and 'getDefaultLanguage' to the 'Aiphilos\Api\ClientInterface' interface.

During development using this SDK, I noticed that the items client class has a dependency on these methods that is not covered by any of the interfaces it implements but only by the AbstractClient that both the semantics and items client extend.
Checking further, I saw that the semantics client has the same 'hidden' dependency.

This means that the provided interfaces are insufficient to abstract and use the actual implementations.
It seems clear to me that this is not intended as each interface for each client looks like they are supposed to be fully sufficient abstraction for the concrete types.

Therefore I have pulled up the definitions for these methods to the shared client interface which solves the issue.